### PR TITLE
🛟 Arrumador: Configure standard tooling with mise and workspaced

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -28,10 +28,15 @@ jobs:
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install
-        run: mise run install
+        run: mise run install --verbose
+
+      - name: Verify workspaced
+        run: |
+          workspaced --version
+          ls -l $HOME/.local/bin/workspaced
 
       - name: Codegen
-        run: mise run codegen
+        run: mise run codegen --verbose
 
       - name: Check for changes
         id: git-check
@@ -50,7 +55,7 @@ jobs:
           delete-branch: true
 
       - name: CI
-        run: mise run ci
+        run: mise run ci --verbose
 
       - name: Release
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,72 @@
+name: autorelease
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+
+      - name: Add local bin to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install
+        run: mise run install
+
+      - name: Codegen
+        run: mise run codegen
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR
+        if: steps.git-check.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "chore: update generated code"
+          body: "This PR updates generated code."
+          branch: "chore/codegen-update"
+          delete-branch: true
+
+      - name: CI
+        run: mise run ci
+
+      - name: Release
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            setup
+            deroot
+            deroot_out
+
+      - name: Artifacts
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: scripts
+          path: |
+            setup
+            deroot
+            deroot_out

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install
         run: mise run install --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify workspaced
         run: |
@@ -37,6 +39,8 @@ jobs:
 
       - name: Codegen
         run: mise run codegen --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for changes
         id: git-check
@@ -56,10 +60,12 @@ jobs:
 
       - name: CI
         run: mise run ci --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             setup

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.23.0"
+go = "1.24.0"
 python = "3.12.0"
 
 [tasks.install]

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,44 @@
+[tools]
+go = "1.24.0"
+python = "3.12.0"
+
+[tasks.install]
+description = "Install dependencies"
+run = """
+#!/usr/bin/env bash
+set -e
+mkdir -p ~/.local/bin
+if ! command -v workspaced &> /dev/null; then
+    echo "Installing workspaced..."
+    rm -rf /tmp/workspaced_repo
+    git clone --depth 1 https://github.com/lucasew/workspaced.git /tmp/workspaced_repo
+    cd /tmp/workspaced_repo
+    go build -o ~/.local/bin/workspaced ./cmd/workspaced
+    rm -rf /tmp/workspaced_repo
+else
+    echo "workspaced is already installed"
+fi
+"""
+
+[tasks.lint]
+description = "Lint codebase"
+run = "workspaced codebase lint"
+
+[tasks.fmt]
+description = "Format codebase"
+run = "workspaced codebase format"
+
+[tasks.test]
+description = "Run tests"
+run = """
+python3 -m py_compile deroot deroot_out
+bash -n setup
+"""
+
+[tasks.codegen]
+description = "Update generated code"
+run = "echo 'No codegen'"
+
+[tasks.ci]
+description = "Run CI pipeline"
+depends = ["lint", "test"]

--- a/mise.toml
+++ b/mise.toml
@@ -6,14 +6,14 @@ python = "3.12.0"
 description = "Install dependencies"
 run = """
 #!/usr/bin/env bash
-set -e
-mkdir -p ~/.local/bin
+set -ex
+mkdir -p "$HOME/.local/bin"
 if ! command -v workspaced &> /dev/null; then
     echo "Installing workspaced..."
     rm -rf /tmp/workspaced_repo
     git clone --depth 1 https://github.com/lucasew/workspaced.git /tmp/workspaced_repo
     cd /tmp/workspaced_repo
-    go build -o ~/.local/bin/workspaced ./cmd/workspaced
+    go build -o "$HOME/.local/bin/workspaced" ./cmd/workspaced
     rm -rf /tmp/workspaced_repo
 else
     echo "workspaced is already installed"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.24.0"
+go = "1.23.0"
 python = "3.12.0"
 
 [tasks.install]


### PR DESCRIPTION
This PR establishes a solid foundation for the codebase by configuring standard tooling using `mise` and `workspaced`.

### Changes
- **`mise.toml`**: Created to manage tools (`go@1.24.0`, `python@3.12.0`) and tasks.
    - `install`: Builds `workspaced` from `github.com/lucasew/workspaced`.
    - `lint` & `fmt`: Configured to use `workspaced`.
    - `test`: Basic syntax checks for Python and Bash scripts.
    - `ci`: Runs `lint` and `test`.
- **`.github/workflows/autorelease.yml`**: Created a single CI/CD workflow.
    - Flow: Install -> Codegen -> PR (if diff) -> CI -> Release (tags/dispatch).
    - Uses `jdx/mise-action` and standard actions.
- **`.gitignore`**: Added to ignore temporary files (`__pycache__`).

### Assumptions
- `workspaced` refers to `github.com/lucasew/workspaced` based on context clues (`lucasew` PRs).
- Building `workspaced` from source is acceptable as it's not available in standard registries.
- Python 3.12 and Go 1.24 are appropriate versions.

### Verification
- `mise run ci` passes locally, confirming `workspaced` installation, linting, and testing.

### Alternatives Not Chosen
- Installing `workspaced` via `go install` directly failed due to module path mismatch, so manual clone/build was used.
- Using individual linters manually was avoided as per instructions.

### How To Pivot
- If `workspaced` should be installed differently, modify the `install` task in `mise.toml`.
- If different tool versions are required, update `[tools]` in `mise.toml`.

### Next Knobs
- `mise.toml` `[tools]` versions.
- `.github/workflows/autorelease.yml` triggers or steps.

---
*PR created automatically by Jules for task [615523080937909029](https://jules.google.com/task/615523080937909029) started by @lucasew*