### PR TITLE
📝 Docs: Add docstrings and comments explaining context bridging to core scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/deroot
+++ b/deroot
@@ -1,12 +1,28 @@
 #!/usr/bin/env python3
 
+"""
+deroot - Root-to-User Context Bridge
+
+This script is the entry point used by root (the default Colab user) to execute
+commands as the non-root 'colab' user. Because `su - colab` strips the environment
+variables that Google Colab relies on (like PATHs to pre-installed libraries),
+this script serializes `environ` and `argv` into a temporary JSON file.
+
+The companion script `deroot_out` is then invoked as the 'colab' user,
+which deserializes this state and reconstructs the necessary execution context
+before running the intended command.
+"""
+
 from tempfile import mktemp
 from json import dump
 from sys import argv, stdin, stdout, stderr
 from subprocess import Popen
 from os import environ
 
+# Generate a temporary filename to pass context securely across the su boundary.
 fname = mktemp()
+
+# Capture all current root environment variables and arguments.
 state = dict(env={}, argv=argv[1:])
 for (k, v) in environ.items():
     state['env'][k] = v
@@ -14,6 +30,8 @@ for (k, v) in environ.items():
 with open(fname, 'w') as f:
     dump(state, f)
 
+# Execute deroot_out as the non-root 'colab' user, passing the path to the state file.
+# stdin, stdout, and stderr are forwarded to allow interactive commands and piping.
 p = Popen(['su', '-', 'colab', '-c', f"deroot_out {fname}"], stdin = stdin, stdout = stdout, stderr = stderr)
 p.wait()
 

--- a/deroot_out
+++ b/deroot_out
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
 
+"""
+deroot_out - Environment Reconstructor and Executor
+
+This script runs as the non-root 'colab' user and receives execution context
+from the `deroot` script via a JSON file. Its primary responsibility is to
+reassemble the environment, explicitly injecting Nix profile paths ahead of
+the standard Colab library paths to ensure Nix-installed binaries and libraries
+take precedence, while still falling back to the default Colab ones.
+"""
+
 from getpass import getuser
 from sys import argv, stdin, stdout, stderr
 from json import load
@@ -12,6 +22,10 @@ if getuser() == "root":
 filename = argv[1]
 
 def append_var(env, key, sep = ":"):
+    """
+    Appends Nix-specific paths to a path-like environment variable.
+    Ensures that Nix profiles take priority over system/Colab defaults.
+    """
     parts = []
     if key == "LD_LIBRARY_PATH" or key == "LIBRARY_PATH":
         parts.append(f"{env.get('HOME')}/.nix-profile/lib")
@@ -29,12 +43,20 @@ def append_var(env, key, sep = ":"):
 with open(filename, 'r') as f:
     args = load(f)
     env = args['env']
+
+    # Override HOME so tools know they're operating within the non-root user directory.
     env['HOME'] = "/content/user"
+
+    # Explicitly append/prepend Nix priorities for these specific variables
+    # to avoid clashing with Colab's default container environment setup.
     env = append_var(env, '__EGL_VENDOR_LIBRARY_DIRS')
     env = append_var(env, 'LD_LIBRARY_PATH')
     env = append_var(env, 'LIBRARY_PATH')
     env = append_var(env, 'PATH')
     env = append_var(env, 'MANPATH')
+
+    # Remove LD_PRELOAD to prevent root-owned libraries from conflicting
+    # with the 'colab' user's execution environment.
     env.pop("LD_PRELOAD")
     p = Popen(args['argv'], env = env, stdin = stdin, stdout = stdout, stderr = stderr)
     p.wait()

--- a/setup
+++ b/setup
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
+#
+# Initializes a non-root environment in Google Colab to allow safe Nix installation.
+# This script sets up the 'colab' user, configures passwordless sudo,
+# installs utility scripts (deroot/deroot_out) into the system path,
+# and performs a multi-user Nix installation with flakes enabled.
+#
+# Context: Google Colab runs as root by default. Nix multi-user installation
+# strongly expects to be run in a non-root context with standard permissions.
 
 # Busca da pasta atual onde o script foi clonado
 CURRENT_DIR=`cd "$(dirname "$0")"; pwd`
 
 # Criação do usuário não root e autorização para sudo
+# Colab typically mounts /content; we need the non-root user to access it.
 chmod 777 /content
 
 if [[ ! -d /content/user ]]; then
@@ -15,6 +24,8 @@ fi
 which deroot >/dev/null 2>/dev/null || {
     echo "Installing deroot wrapper script..."
     # Instalação dos scripts utilitários
+    # These wrappers are necessary to transition from the default root environment
+    # into the 'colab' user's context, carrying over environment variables.
     install -m755 "$CURRENT_DIR/deroot" /bin
     install -m755 "$CURRENT_DIR/deroot_out" /bin
 }
@@ -22,11 +33,17 @@ which deroot >/dev/null 2>/dev/null || {
 if [[ ! -d /nix ]]; then
     echo "Installing nix..."
     # Instalação do nix em modo multiuser
+    # Create the /nix store and give ownership to the 'colab' user for installation.
     mkdir -m 0755 /nix && chown colab /nix
     curl -L https://nixos.org/nix/install > /tmp/nix-install
     mkdir -p /etc/nix
+    # Colab uses a containerized environment which often breaks Nix's sandbox
     echo 'sandbox = false' > /etc/nix/nix.conf
+
+    # Run the Nix installer as the 'colab' user using the deroot wrapper
     yes y | deroot sh /tmp/nix-install # --daemon
+
+    # Enable modern Nix features and authorize users to control the Nix daemon
     echo 'experimental-features = nix-command flakes' >> /etc/nix/nix.conf
     echo 'sandbox = false' >> /etc/nix/nix.conf
     echo 'trusted-users = colab root @wheel' >> /etc/nix/nix.conf


### PR DESCRIPTION
**Assumptions**
- The user wanted to add documentation and clarify the complex logic and environment handling inside the core scripts (`setup`, `deroot`, `deroot_out`).
- While modifying executable logic was prohibited, excluding automatically generated python bytecode artifacts (`__pycache__`) in `.gitignore` was necessary to adhere to strict repository hygiene.

**Alternatives Not Chosen**
- Creating `AGENTS.md` initially, but pivoting back as the prompt specifically demanded exploring the codebase and adding docstrings to existing code to fix drift or gaps.
- Leaving the scripts undocumented, which was severely impacting readability and onboarding as the root-to-non-root Google Colab boundary logic was obscure.

**How To Pivot**
- If the documentation needs adjustment, amend the docstrings in the Python files (`deroot`, `deroot_out`) or the shell comments in `setup`.
- To drop the `.gitignore` change, perform `git reset HEAD~1 .gitignore && git checkout .gitignore`.

**Next Knobs**
- Check out `deroot` and `deroot_out` comments for further context on environment parsing.
- Explore `setup` for more information on user configuration inside Google Colab.

---
*PR created automatically by Jules for task [10091079523505882845](https://jules.google.com/task/10091079523505882845) started by @lucasew*