### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure temporary file creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2024-05-20: [High] tempfile.mktemp is vulnerable to race conditions; use mkstemp or NamedTemporaryFile instead.

--- a/deroot
+++ b/deroot
@@ -1,19 +1,33 @@
 #!/usr/bin/env python3
 
-from tempfile import mktemp
+from tempfile import mkstemp
 from json import dump
 from sys import argv, stdin, stdout, stderr
 from subprocess import Popen
-from os import environ
+from os import environ, fdopen, remove, chown, chmod
+import pwd
 
-fname = mktemp()
+fd, fname = mkstemp()
+try:
+    colab_uid = pwd.getpwnam('colab').pw_uid
+    chown(fname, colab_uid, -1)
+except KeyError:
+    pass # If user doesn't exist, ignore (e.g. tests)
+
+chmod(fname, 0o400) # Only owner can read
+
 state = dict(env={}, argv=argv[1:])
 for (k, v) in environ.items():
     state['env'][k] = v
 
-with open(fname, 'w') as f:
+with fdopen(fd, 'w') as f:
     dump(state, f)
 
-p = Popen(['su', '-', 'colab', '-c', f"deroot_out {fname}"], stdin = stdin, stdout = stdout, stderr = stderr)
-p.wait()
-
+try:
+    p = Popen(['su', '-', 'colab', '-c', f"deroot_out {fname}"], stdin = stdin, stdout = stdout, stderr = stderr)
+    p.wait()
+finally:
+    try:
+        remove(fname)
+    except OSError:
+        pass


### PR DESCRIPTION
Severity: HIGH
Vulnerability: `tempfile.mktemp` is deprecated and vulnerable to symlink attacks/race conditions. Additionally, the temporary file created by `deroot` contains a full dump of the execution environment variables (which may include secrets/tokens) and was previously never deleted, leading to a severe information leak on the filesystem.
Impact: Local users or an attacker could potentially intercept the filename before creation, read sensitive environment variables leaked into `/tmp`, or exhaust `/tmp` storage.
Fix:
1. Replaced `mktemp()` with `mkstemp()`.
2. Explicitly transferred ownership of the generated state file to the `colab` user using `os.chown` and restricted permissions to `0400` (`chmod`) to prevent unauthorized access by other local users.
3. Added a `try...finally` block to ensure the state file is securely removed after the child process terminates, preventing data leakage.
Verification: Ran basic syntax checks and validated that file modifications respect directory restrictions while securely bridging root to non-root execution context.

### Assumptions
- The `deroot` script runs as a privileged user (`root`) capable of `chown`ing files to the `colab` user.
- The `colab` user must exist for `chown` to succeed; gracefully falls back if not present.

### Alternatives Not Chosen
- Passing state via `stdin`: Rejected because `deroot_out` relies heavily on reading from a specified file path parameter, requiring a significantly larger refactoring footprint across scripts.
- Moving files to `src/`: Rejected to avoid merge conflicts with an already open, mergeable PR (#3) that handles this repository reorganization.

### How To Pivot
If `colab` is not consistently the target user, parameterize the username or adjust the `chown` logic to pull from `su - [user]`.

### Next Knobs
- `colab` string in `pwd.getpwnam('colab')` inside `deroot`.
- File permission constant `0o400` inside `deroot` (if additional group read is needed).

---
*PR created automatically by Jules for task [7945384835233803644](https://jules.google.com/task/7945384835233803644) started by @lucasew*