### PR TITLE
📝 Docs: Add context bridging docstrings to core scripts

### DIFF
--- a/deroot
+++ b/deroot
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+"""
+Wrapper script (root to non-root). Dumps the root user's execution environment into a temporary JSON file and transitions execution context to `colab` user via `su`.
+This is necessary because Google Colab runs as root, which can cause issues with Nix.
+"""
+
 from tempfile import mktemp
 from json import dump
 from sys import argv, stdin, stdout, stderr

--- a/deroot_out
+++ b/deroot_out
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
+"""
+Reconstructor script (non-root side). Rebuilds the environment from the temporary JSON file, overriding paths (`PATH`, `LD_LIBRARY_PATH`, `MANPATH`, `__EGL_VENDOR_LIBRARY_DIRS`) to give precedence to the Nix profile.
+This ensures the `colab` user has access to Nix tools and libraries without polluting the root environment.
+"""
+
 from getpass import getuser
 from sys import argv, stdin, stdout, stderr
 from json import load

--- a/setup
+++ b/setup
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Primary entry point script for nix-on-colab.
-# It clones the repository into Colab, creates the non-root `colab` user with sudo privileges, and installs Nix in multi-user mode.
+# It creates the non-root `colab` user with sudo privileges, installs utility scripts, and installs Nix in multi-user mode.
 
 # Busca da pasta atual onde o script foi clonado
 CURRENT_DIR=`cd "$(dirname "$0")"; pwd`

--- a/setup
+++ b/setup
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
+# Primary entry point script for nix-on-colab.
+# It clones the repository into Colab, creates the non-root `colab` user with sudo privileges, and installs Nix in multi-user mode.
+
 # Busca da pasta atual onde o script foi clonado
 CURRENT_DIR=`cd "$(dirname "$0")"; pwd`
 
 # Criação do usuário não root e autorização para sudo
+# This is necessary because Nix doesn't play well when run exclusively as the root user.
 chmod 777 /content
 
 if [[ ! -d /content/user ]]; then


### PR DESCRIPTION
📝 Docs: Add context bridging docstrings to core scripts

## Description
This PR addresses the missing documentation in the core context bridging scripts (`deroot` and `deroot_out`) and the primary entry point (`setup`). 

It adds high-value module-level docstrings and Bash comments to explain the *why* (Colab's root user conflicts with Nix) and the *execution flow* (dumping environment to a temporary JSON file, transitioning to the non-root `colab` user, and overriding paths to give precedence to Nix).

## Assumptions
- The execution flow between `setup` -> `deroot` -> `deroot_out` is stable and correctly represents the context bridging.
- Module-level Python docstrings (after shebang) are the standard way to document script responsibilities.
- The `mise` configuration and standard linters (`workspaced`) are introduced in other open PRs, so `mise run lint` failing is expected here.

## Alternatives Not Chosen
- Did not change any variable names or refactor the code to make the flow "clearer," strictly adhering to the "do not change executable logic" directive.
- Did not add line-by-line comments inside the Python scripts, preferring a high-level module docstring to explain the overall bridging mechanism as requested (Essentialism).

## How To Pivot
- If the documentation needs to cover individual functions within `deroot_out` instead of just the module level, the module docstring can be removed or shortened, and standard function docstrings (e.g., for `append_var`) can be added instead.

## Next Knobs
- `deroot`: Expand the docstring to list the specific environment variables that are dumped.
- `setup`: Add inline comments explaining the multi-user Nix installation command specifically.
- `deroot_out`: Document the `append_var` helper function explicitly if needed.

---
*PR created automatically by Jules for task [12341021147775891995](https://jules.google.com/task/12341021147775891995) started by @lucasew*